### PR TITLE
add support for poolmon, enhance FreeBSD support

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,5 +1,6 @@
 ---
 dovecot::package_name: ['dovecot-core']
+dovecot::poolmon_config_file: '/etc/default/poolmon'
 dovecot::plugin:
   antispam:
     package_name: ['dovecot-antispam']

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -6,4 +6,9 @@ dovecot::plugin:
     package_name: ['mail/dovecot-pigeonhole']
   sieve:
     package_name: ['mail/dovecot-pigeonhole']
+dovecot::poolmon_basepath: '/usr/local'
+dovecot::poolmon_config_file: '/etc/rc.conf.d/poolmon'
+dovecot::poolmon_service_file: '/usr/local/etc/rc.d/poolmon'
+dovecot::poolmon_service_mode: '0755'
+dovecot::poolmon_service_provider: 'rc'
 dovecot::sieve::sievec: '/usr/local/bin/sievec'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,5 +1,6 @@
 ---
 dovecot::package_name: ['dovecot']
+dovecot::poolmon_config_file: '/etc/sysconfig/poolmon'
 dovecot::plugin:
   managesieve:
     package_name: ['dovecot-pigeonhole']

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,12 @@
 ---
+lookup_options:
+  # Usually you want to REPLACE (not merge) package lists.
+  '^dovecot::(.*::)?package_name$':
+    merge:
+      strategy: first
+  '^dovecot::.*':
+    merge:
+      strategy: deep
 dovecot::config_path: '/etc/dovecot'
 dovecot::config: {}
 dovecot::configs: {}
@@ -6,6 +14,29 @@ dovecot::package_ensure: 'present'
 dovecot::package_manage: true
 dovecot::plugin: {}
 dovecot::plugins: []
+dovecot::poolmon_archive_params:
+  checksum_type: 'none'
+  cleanup: true
+  extract: true
+dovecot::poolmon_basepath: '/opt'
+dovecot::poolmon_checksum_type: 'none'
+dovecot::poolmon_config:
+  scan_interval: 30
+  check_timeout: 5
+  log_debug: false
+  logfile: 'syslog'
+  check_port:
+    - 110
+    - 143
+  check_ssl: []
+  socket: '/var/run/dovecot/director-admin'
+  lockfile: '/var/run/poolmon.pid'
+dovecot::poolmon_exec: '/usr/local/sbin/poolmon'
+dovecot::poolmon_manage: false
+dovecot::poolmon_service_file: '/etc/systemd/system/poolmon.service'
+dovecot::poolmon_service_mode: '0644'
+dovecot::poolmon_service_provider: 'systemd'
+dovecot::poolmon_version: '0.6'
 dovecot::purge_unmanaged: true
 dovecot::service_enable: true
 dovecot::service_ensure: running

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -21,7 +21,7 @@ define dovecot::configfile (
 ) {
   concat { $file:
     owner  => 'root',
-    group  => 'root',
+    group  => 0,
     mode   => '0644',
     warn   => !$comment,
     order  => 'alpha',

--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -7,11 +7,13 @@ class dovecot::configuration inherits dovecot {
       path    => $dovecot::config_path,
       recurse => true,
       purge   => true,
-    } ->
-    # always keep conf.d
-    file { "${dovecot::config_path}/conf.d":
-      ensure => 'directory',
+      before  => File["${dovecot::config_path}/conf.d"]
     }
+  }
+
+  # always keep/create conf.d
+  file { "${dovecot::config_path}/conf.d":
+    ensure => 'directory',
   }
 
   dovecot::create_config_resources($dovecot::config)

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -8,7 +8,7 @@
 define dovecot::file(
   $content,
   $path,
-  $group = 'root',
+  $group = 0,
   $mode = '0644',
   $owner = 'root',
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@
 # @param package_manage whether to install the dovecot core and plugin packages
 # @param plugin contains a package_name parameter for each plugin (if available)
 # @param plugins the list of plugins to install
+# @param poolmon_manage [Boolean] Whether to manage the poolmon service. Default value: false.
 # @param purge_unmanaged whether to purge all unmanaged files in the dovecot directory
 # @param service_enable [Boolean] Whether to enable the dovecot service at boot. Default value: true.
 # @param service_ensure [Enum['running', 'stopped']] Whether the dovecot service should be running. Default value: 'running'.
@@ -31,12 +32,21 @@
 #
 class dovecot(
   Hash $config,
-  #Hash $config = {},
   String $config_path,
   Hash $configs,
   String $package_ensure,
   Boolean $package_manage,
   Array[String] $package_name,
+  Hash $poolmon_archive_params,
+  String $poolmon_basepath,
+  Hash $poolmon_config,
+  String $poolmon_config_file,
+  String $poolmon_exec,
+  Boolean $poolmon_manage,
+  String $poolmon_service_file,
+  String $poolmon_service_mode,
+  Enum['rc', 'systemd'] $poolmon_service_provider,
+  String $poolmon_version,
   Boolean $purge_unmanaged,
   Hash $plugin,
   Array[String[1]] $plugins,
@@ -48,8 +58,10 @@ class dovecot(
   contain dovecot::install
   contain dovecot::configuration
   contain dovecot::service
+  contain dovecot::poolmon
 
   Class['::dovecot::install']
   -> Class['::dovecot::configuration']
   ~> Class['::dovecot::service']
+  ~> Class['::dovecot::poolmon']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,15 +8,11 @@ class dovecot::install inherits dovecot {
 
     # get a list of package names for all requested plugins
     $_list = $dovecot::plugins.map |$_plugin| {
-      if ($dovecot::plugin[$_plugin]) {
-        if ($dovecot::plugin[$_plugin]['package_name']) {
-          $dovecot::plugin[$_plugin]['package_name']
-        }
-      }
+      $dovecot::plugin.dig($_plugin, 'package_name')
     }
 
     # remove duplicates from the list
-    $packages = unique($_list)
+    $packages = unique($_list).filter|$value| { $value != undef }
 
     # install plugin packages
     $packages.each |$_package| {

--- a/manifests/poolmon.pp
+++ b/manifests/poolmon.pp
@@ -1,0 +1,95 @@
+# @api private 
+# This class handles poolmon. Avoid modifying private classes.
+class dovecot::poolmon inherits dovecot {
+  if ($dovecot::poolmon_manage) {
+
+    $dirname = "poolmon-${dovecot::poolmon_version}"
+    $filename = "${dirname}.tar.gz"
+    $install_path = "${dovecot::poolmon_basepath}/${dirname}"
+
+    file { $install_path:
+      ensure => directory,
+      mode   => '0775',
+    }
+
+    # merge default config with user-defined values
+    $_archive_params = {
+      path          => "/tmp/${filename}",
+      source        => "https://github.com/brandond/poolmon/archive/${dovecot::poolmon_version}.tar.gz",
+      extract_path  => $dovecot::poolmon_basepath,
+      creates       => "${install_path}/poolmon",
+      require       => File[$install_path],
+    }
+    $archive_params = deep_merge($_archive_params, $dovecot::poolmon_archive_params)
+
+    # download poolmon
+    archive { $filename:
+      * => $archive_params
+    }
+
+    file { $dovecot::poolmon_exec:
+      ensure  => link,
+      target  => "${install_path}/poolmon",
+      require => Archive[$filename],
+    }
+
+    # optional file containing credentials for dovecot director
+    if ($dovecot::poolmon_config['username'] =~ String) and
+      ($dovecot::poolmon_config['password'] =~ String) {
+      $poolmon_credfile = "${dovecot::poolmon_config_file}.cred"
+      $_template = '<%= $username %><%= "\n" %><%= $password %>'
+      file { $poolmon_credfile:
+        ensure  => 'present',
+        mode    => '0600',
+        content => inline_epp($_template,{
+          username => $dovecot::poolmon_config['username'],
+          password => $dovecot::poolmon_config['password']
+          }),
+        before  => [
+          File[$dovecot::poolmon_config_file],
+          Service['poolmon'],
+        ]
+      }
+    }
+
+    # create service configuration file
+    file { $dovecot::poolmon_config_file:
+      ensure  => 'present',
+      mode    => '0600',
+      content => epp('dovecot/poolmon.config',{
+        logfile       => $dovecot::poolmon_config['logfile'],
+        lockfile      => $dovecot::poolmon_config['lockfile'],
+        socket        => $dovecot::poolmon_config['socket'],
+        log_debug     => $dovecot::poolmon_config['log_debug'],
+        scan_interval => $dovecot::poolmon_config['scan_interval'],
+        check_timeout => $dovecot::poolmon_config['check_timeout'],
+        lmtp_from     => $dovecot::poolmon_config['lmtp_from'],
+        lmtp_to       => $dovecot::poolmon_config['lmtp_to'],
+        username      => $dovecot::poolmon_config['username'],
+        password      => $dovecot::poolmon_config['password'],
+        check_port    => $dovecot::poolmon_config['check_port'],
+        check_ssl     => $dovecot::poolmon_config['check_ssl'],
+        credfile      => $poolmon_credfile,
+        provider      => $dovecot::poolmon_service_provider,
+        }),
+    }
+
+    # install service script
+    file { $dovecot::poolmon_service_file:
+      ensure  => 'present',
+      mode    => $dovecot::poolmon_service_mode,
+      content => epp("dovecot/poolmon.service.${dovecot::poolmon_service_provider}"),
+    }
+
+    # enable/start service
+    service { 'poolmon':
+      ensure    => $dovecot::service_ensure,
+      enable    => $dovecot::service_enable,
+      subscribe => [
+          Archive[$filename],
+          File[$dovecot::poolmon_config_file],
+          File[$dovecot::poolmon_service_file]
+        ]
+    }
+  }
+}

--- a/manifests/sieve.pp
+++ b/manifests/sieve.pp
@@ -8,7 +8,7 @@
 #
 define dovecot::sieve(
   $content = undef,
-  $group = 'root',
+  $group = 0,
   $mode = '0644',
   $owner = 'root',
   $path = $name,

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
   "issues_url": "https://github.com/oxc/puppet-dovecot/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 < 5.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 3.0.0 < 5.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 3.0.0 < 5.0.0"},
+    {"name":"puppet/archive","version_requirement":">= 2.0.0 < 3.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/templates/poolmon.config.epp
+++ b/templates/poolmon.config.epp
@@ -1,0 +1,31 @@
+<%- | Optional[String]  $logfile = undef,
+      Optional[String]  $lockfile = undef,
+      Optional[String]  $socket = undef,
+      Optional[Boolean] $log_debug = undef,
+      Optional[Integer] $scan_interval = undef,
+      Optional[Integer] $check_timeout = undef,
+      Optional[String]  $lmtp_from = undef,
+      Optional[String]  $lmtp_to = undef,
+      Optional[Array]   $check_port = undef,
+      Optional[Array]   $check_ssl = undef,
+      Optional[String]  $credfile = undef,
+      Optional[String]  $provider = undef | -%>
+# This file is managed by Puppet. DO NOT EDIT.
+
+<% if ($check_port) { -%>
+<%   $_portopts = $check_port.map |$port| { "--port=${port} " } -%>
+<% } -%>
+<% if ($check_ssl) { -%>
+<%   $_sslopts = $check_ssl.map |$sslport| { "--ssl=${sslport} " } -%>
+<% } -%>
+
+<% if ($provider == 'systemd') { -%>
+<%   $prefix='OPTIONS=' -%>
+<% } elsif ($provider == 'rc') { -%>
+poolmon_enable="YES"
+poolmon_pidfile="<%= $lockfile %>"
+<%   $prefix='poolmon_flags="' -%>
+<%   $suffix='"' -%>
+<% } -%>
+
+<%= $prefix %><% if ($logfile) { %>--logfile="<%= $logfile %>" <% } -%><% if ($lockfile) { %>--lockfile="<%= $lockfile %>" <% } -%><% if ($socket) { %>--socket="<%= $socket %>" <% } -%><% if ($log_debug) { %>--debug <% } -%><% if ($scan_interval) { %>--interval="<%= $scan_interval %>" <% } -%><% if ($check_timeout) { %>--timeout="<%= $check_timeout %>" <% } -%><% if ($lmtp_from) { %>--lmtp-from="<%= $lmtp_from %>" <% } -%><% if ($lmtp_to) { %>--lmtp-to="<%= $lmtp_to %>" <% } -%><% if ($poolmon_credfile) { %>--credfile="<%= $poolmon_credfile %>" <% } -%><%= $_portopts.join('') %> <%= $_sslopts.join('') %><%= $suffix %>

--- a/templates/poolmon.service.rc.epp
+++ b/templates/poolmon.service.rc.epp
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# PROVIDE: poolmon
+# REQUIRE: DAEMON LOGIN dovecot
+# KEYWORD: shutdown
+
+# poolmon_enable (bool):        Set it to YES to enable poolmon
+#                               Default: NO
+# poolmon_flags (str):          Extra flags to pass to poolmon
+#                               Default: empty
+# poolmon_pidfile (file):       Set full path to pid file.
+
+. /etc/rc.subr
+
+stop_precmd()
+{
+	test -f $pidfile && kill -9 $(cat $pidfile)
+}
+
+name="poolmon"
+rcvar="poolmon_enable"
+
+load_rc_config ${name}
+
+: ${poolmon_enable:="NO"}
+: ${poolmon_pidfile:="/var/run/poolmon.pid"}
+
+command="<%= $dovecot::poolmon_exec %>"
+command_interpreter="/usr/bin/perl"
+pidfile=${poolmon_pidfile}
+stop_precmd=stop_precmd
+sig_stop="TERM"
+
+run_rc_command "$1"

--- a/templates/poolmon.service.systemd.epp
+++ b/templates/poolmon.service.systemd.epp
@@ -1,0 +1,17 @@
+[Unit]
+Description=Poolmon monitors a pool of Dovecot director mailservers
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=simple
+EnvironmentFile=-<%= $dovecot::poolmon_config_file %>
+WorkingDirectory=/
+PIDFile=<%= $dovecot::poolmon_config['lockfile'] %>
+ExecStart=<%= $dovecot::poolmon_exec %> -f ${OPTIONS}
+Restart=on-failure
+LimitNOFILE=10000
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
So this PR is (again) larger than expected. Sorry for that.

Key points:
* Add support for poolmon to monitor instances of dovecot director
  * Supports Linux systems running systemd and the FreeBSD operating system
  * New dependency: puppet/archive (required to download/distribute poolmon)
* Specify "lookup_options" to fix `*::package_name` parameters: they should not be merged, to allow overwriting package names
* Change `group` parameters from `root` to `0` to support FreeBSD (where group "root" is known as "wheel")
* Ensure that `$config_path/conf.d` exists (it's not available by default on FreeBSD)
