### PR TITLE
Feature/extfiles

### DIFF
--- a/functions/create_config_file_resources.pp
+++ b/functions/create_config_file_resources.pp
@@ -28,10 +28,21 @@ function dovecot::create_config_file_resources(
     $file_params = {
       file => $key
     } + $params
-    dovecot::create_config_resources($value, $file_params)
-    dovecot::config { "dovecot.conf !include ${key} ${value}":
-      key   => '!include',
-      value => "conf.d/${key}.conf",
+
+    if $key =~ /\.conf\.ext$/ {
+      $ext = true
+    } else {
+      $ext = false
+    }
+
+    if $include_in_main_config and ! $ext {
+      dovecot::create_config_resources($value, $file_params)
+      dovecot::config { "dovecot.conf !include ${key} ${value}":
+        key   => '!include',
+        value => "conf.d/${key}.conf",
+      }
+    } else {
+      dovecot::create_config_resources($value, $file_params)
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,12 +90,6 @@ define dovecot::config (
     $configkey = pick($key, $name)
   }
 
-  # if $key =~ /\.conf\.ext$/ {
-  #   $ext = true
-  # } else {
-  #   $ext = false
-  # }
-
   $full_file = $configfile ? {
     /\.conf\.ext$/ => "${dovecot::config_path}/${configfile}",
     Undef   => "${dovecot::config_path}/dovecot.conf",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,7 +90,14 @@ define dovecot::config (
     $configkey = pick($key, $name)
   }
 
+  # if $key =~ /\.conf\.ext$/ {
+  #   $ext = true
+  # } else {
+  #   $ext = false
+  # }
+
   $full_file = $configfile ? {
+    /\.conf\.ext$/ => "${dovecot::config_path}/${configfile}",
     Undef   => "${dovecot::config_path}/dovecot.conf",
     default => "${dovecot::config_path}/conf.d/${configfile}.conf"
   }


### PR DESCRIPTION
added functionality (quickfix) to allow configuring `.conf.ext` files which are not included in `dovecot.conf` and can be written directly in `/etc/dovecot` and `/etc/dovecot/conf.d` to allow the use of for example `args: /etc/dovecot/dovecot-sql.conf.ext` 

refs: #6 

```
dovecot::configs:
  'conf.d/auth-sql.conf.ext':
    passdb:
      driver: sql
      args: /etc/dovecot/dovecot-sql.conf.ext
  'dovecot-sql.conf.ext':
    driver: pgsql
    connect: host=127.0.0.1 dbname=mailserver user=mailuser password=ChangeMe
    default_pass_scheme: SHA256-CRYPT
    password_query: "SELECT email as user, password FROM virtual_users WHERE email='%u';"
  '10-auth':
    auth_mechanisms: plain login
    disable_plaintext_auth: yes
```

edit: additionaly fixed a bug. `functions/create_config_file_resources.pp` contains the parameter `$include_in_main_config`  which was ignored in the function. refs #8 