### PR TITLE
Added metadata Plugin

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -17,6 +17,8 @@ dovecot::plugin:
     package_name: ['dovecot-lucene']
   managesieve:
     package_name: ['dovecot-managesieved']
+  metadata:
+    package_name: ['dovecot-metadata-plugin']
   mysql:
     package_name: ['dovecot-mysql']
   pgsql:


### PR DESCRIPTION
Hi,

since Ubuntu 18.04 LTS there is a METADATA Plugin for dovecot:

https://packages.ubuntu.com/bionic/dovecot-metadata-plugin