### PR TITLE
README: add missing entry to ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
     * [What this module affects](#what-this-module-affects)
     * [Configuration options](#configuration-options)
     * [External config files](#external-config-files)
+    * [Poolmon configuration](#poolmon-configuration)
 1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 1. [Limitations - OS compatibility, etc.](#limitations)
     * [Compatibility](#compatibility)


### PR DESCRIPTION
I forgot to add the ToC entry for the new poolmon section in my previous PR. Sorry about that.