### PR TITLE
Ensure conf.d and private are purged with purge_unmanaged: true

### DIFF
--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -14,6 +14,8 @@ class dovecot::configuration inherits dovecot {
   # always keep/create conf.d
   file { "${dovecot::config_path}/conf.d":
     ensure => 'directory',
+    recurse => $dovecot::purge_unmanaged,
+    purge   => $dovecot::purge_unmanaged,
   }
 
   if ($dovecot::directory_private_manage) {
@@ -21,6 +23,8 @@ class dovecot::configuration inherits dovecot {
     # default) manage it to keep log noise low on package updates
     file { "${dovecot::config_path}/private":
       ensure => 'directory',
+      recurse => $dovecot::purge_unmanaged,
+      purge   => $dovecot::purge_unmanaged,
     }
   }
 


### PR DESCRIPTION
This should fix #21 
It seems, since the `conf.d` directory is a managed directory, the upper level purge of `/etc/dovecot` does not take effect. Explicitly setting purge and recurce to `true` for both subdir declarations works.

We coud also do this with an additional parameter to allow purging only `/etc/dovecot`, or only `conf.d` or only `private`. But since the initial thought was to recursively purge all subdirs this might be good enough.