### PR TITLE
Document support for CentOS 7/Puppet 6/Dovecot 2.2.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This module installs and manages the dovecot imap server and its plugins, and pr
 resources and functions to configure the dovecot system.
 It does, however, not configure any of those systems beyond the upstream defaults.
 
-This module is intended to work with Puppet 5, tested dovceot and OS versions are listed
-below. Patches to support other setups are welcome.
+This module is intended to work with Puppet 5 and 6, tested dovceot and OS versions are
+listed below. Patches to support other setups are welcome.
 
 ## Setup and Usage
 
@@ -225,7 +225,9 @@ OS Versions tested:
 
 dovecot versions tested:
 
-* 2.2.10, 2.2.22
+* 2.2.10
+* 2.2.22
+* 2.2.36
 
 Feel free to let me know if it correctly works on a different OS/setup, or
 submit patches if it doesn't.

--- a/metadata.json
+++ b/metadata.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 < 6.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 3.0.0 < 6.0.0"},
-    {"name":"puppet/archive","version_requirement":">= 2.0.0 < 4.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 3.0.0 < 7.0.0"},
+    {"name":"puppet/archive","version_requirement":">= 2.0.0 < 5.0.0"}
   ],
   "operatingsystem_support": [
     {
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.9.0 < 6.0.0"
+      "version_requirement": ">= 4.9.0 < 7.0.0"
     }
   ],
   "data_provider": null


### PR DESCRIPTION
This module is used since Puppet 5.x with various Rspamd versions on
CentOS 7;  recent module upgrades were blocked by this module due to its
dependencies on old concat and archive module versions, but tests showed
that it is compatible with recent/latest versions of all components out
of the box.

Crank all required versions such that future module updates will work
without conflicts.