### PR TITLE
Increase max valid stdlib version to meet the latest versions > 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     "poolmon"
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 < 6.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 < 7.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 3.0.0 < 7.0.0"},
     {"name":"puppet/archive","version_requirement":">= 2.0.0 < 5.0.0"}
   ],


### PR DESCRIPTION
This will address #24 I did not see any issues during testing with the latest stdlib version (6.3.0)